### PR TITLE
FEAT: Auto-assign Authenticated User as Comment Author

### DIFF
--- a/apps/posts/serializers.py
+++ b/apps/posts/serializers.py
@@ -6,7 +6,7 @@ class CommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
         fields = ['id', 'text', 'author', 'post', 'created_at']
-        extra_kwargs = {'post': {'read_only': True}}
+        extra_kwargs = {'post': {'read_only': True}, 'author': {'read_only': True}}
         
     def to_representation(self, instance):
         response = super().to_representation(instance)

--- a/apps/posts/views.py
+++ b/apps/posts/views.py
@@ -98,6 +98,7 @@ class PostDetailView(APIView):
 # Comment List View for a specific post
 class CommentListView(APIView):
     serializer_class = CommentSerializer
+    permission_classes = [IsAuthenticated]
 
     def get(self, request, post_id):
         try:
@@ -132,7 +133,7 @@ class CommentListView(APIView):
         # Check if the data is valid
         if serializer.is_valid():
             # Save the data to the database
-            serializer.save(post=post)
+            serializer.save(post=post, author=request.user)
             # Return the JSON data
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         # If the data is not valid, return an error


### PR DESCRIPTION
This PR refactors the comment creation process by automatically assigning the authenticated user as the author of the comment. 

The changes include:

- Making the author field read-only in the CommentSerializer, so it is no longer required in the request body.
- The logged-in user is now automatically set as the comment's author when creating a comment.
- Simplified the comment creation API by removing the need for the author field in the request payload.