### PR TITLE
Refactor Follow/Unfollow API to Toggle Follow State

### DIFF
--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -125,30 +125,20 @@ class FollowSerializer(serializers.ModelSerializer):
         user_to_follow = data['user_id']
         follower = self.context['request'].user
 
-        # Check if the user is already being followed
-        if Follow.objects.filter(follower=follower, followed=user_to_follow).exists():
-            raise ValidationError("You are already following this user.")
-        
-        data['followed'] = user_to_follow
-        data['follower'] = follower
+        # Check if a follow record exists
+        follow_instance = Follow.objects.filter(follower=follower, followed=user_to_follow).first()
+
+        if follow_instance:
+            data['to_unfollow'] = follow_instance
+        else:
+            data['followed'] = user_to_follow
+            data['follower'] = follower
         return data
 
     def create(self, validated_data):
+        if 'to_unfollow' in validated_data:
+            validated_data['to_unfollow'].delete()
+            return {'Unfollowed': True}
+
         validated_data.pop('user_id')
-        follow_instance = Follow.objects.create(**validated_data)
-        return follow_instance
-
-    
-class UnfollowSerializer(serializers.Serializer):
-    user_id = serializers.IntegerField()
-
-    def validate_user_id(self, value):
-        try:
-            user_to_unfollow = User.objects.get(id=value)
-        except User.DoesNotExist:
-            raise ValidationError("User to unfollow does not exist.")
-        
-        if self.context['request'].user == user_to_unfollow:
-            raise ValidationError("You cannot unfollow yourself.")
-        
-        return value
+        return Follow.objects.create(**validated_data)

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -12,5 +12,4 @@ urlpatterns = [
     path('profile/posts/', PersonalPostsView.as_view(), name='personal-posts'),
     path('profile/comments/', PersonalCommentsView.as_view(), name='personal-comments'),
     path('follow/', FollowView.as_view(), name='follow'),
-    path('unfollow/', UnfollowView.as_view(), name='unfollow'),
 ]

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -15,7 +15,7 @@ from .models import Profile, Follow
 from .permissions import IsAdmin, IsOwnerOrAdmin
 from .serializers import ProfileSearchSerializer, ProfileSerializer, UserSerializer, RoleSerializer, UserUpdateSerializer
 from rest_framework.generics import ListAPIView
-from .serializers import ProfileSearchSerializer, UserSerializer, RoleSerializer, FollowSerializer, UnfollowSerializer
+from .serializers import ProfileSearchSerializer, UserSerializer, RoleSerializer, FollowSerializer # UnfollowSerializer
 
 class UserListView(ListAPIView):
     permission_classes = [IsAuthenticated, IsAdmin]
@@ -337,24 +337,11 @@ class FollowView(APIView):
         serializer = FollowSerializer(data=request.data, context={'request': request})
         
         if serializer.is_valid():
-            serializer.save()
-            return ResponseFactory.created("Followed Successfully", {"Message": "Followed successfully"})
-        return ResponseFactory.bad_request("Error", {"Error": serializer.errors})
-    
-class UnfollowView(APIView):
-    permission_classes = [IsAuthenticated]
+            result = serializer.save()
 
-    def post(self, request):
-        serializer = UnfollowSerializer(data=request.data, context={'request': request})
+            if isinstance(result, dict):
+                return ResponseFactory.success('Unfollowed Successfully', {'Message': 'Unfollowed successfully'})
+
+            return ResponseFactory.created("Followed Successfully", {"Message": "Followed successfully"})
         
-        if serializer.is_valid():
-            user_id = serializer.validated_data['user_id']
-            user_to_unfollow = User.objects.get(id=user_id)
-            follow_instance = Follow.objects.filter(follower=request.user, followed=user_to_unfollow)
-            
-            if follow_instance.exists():
-                follow_instance.delete()
-                return ResponseFactory.success("User unfollowed successfully", {"Message": "User unfollowed successfully."})
-            return ResponseFactory.bad_request("Not following", {"Message": "You are not following this user."})
         return ResponseFactory.bad_request("Error", {"Error": serializer.errors})
-    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,12 +155,6 @@ def follow_url():
         return reverse('follow')
     return _generate_url
 
-@pytest.fixture
-def unfollow_url():
-    def _generate_url():
-        return reverse('unfollow')
-    return _generate_url
-
 # Mock Data Fixtures
 @pytest.fixture
 def mock_user_data():

--- a/tests/views/test_user_views.py
+++ b/tests/views/test_user_views.py
@@ -405,18 +405,6 @@ def test_follow_user_successfully(auth_login_client, populate_users, follow_url)
     assert response.status_code == status.HTTP_201_CREATED
 
 @pytest.mark.django_db
-def test_follow_user_already_followed(auth_login_client, populate_users, follow_url):
-    user1, user2, _ = populate_users
-    client = auth_login_client(user1.user.username, '1234')
-
-    url = follow_url()
-    response = client.post(url, {"user_id": user2.user.id} ,secure=True, format='json')
-    assert response.status_code == status.HTTP_201_CREATED
-
-    response_2 = client.post(url, {"user_id": user2.user.id} ,secure=True, format='json')
-    assert response_2.status_code == status.HTTP_400_BAD_REQUEST
-
-@pytest.mark.django_db
 def test_user_cannot_follow_themselves(auth_login_client, populate_users, follow_url):
     user1, _, _ = populate_users
     client = auth_login_client(user1.user.username, '1234')
@@ -434,7 +422,7 @@ def test_follow_user_not_found(auth_login_client, populate_users, follow_url):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 @pytest.mark.django_db
-def test_unfollow_user_successfully(auth_login_client, populate_users, follow_url, unfollow_url):
+def test_unfollow_user_successfully(auth_login_client, populate_users, follow_url):
     user1, user2, _ = populate_users
     client = auth_login_client(user1.user.username, '1234')
 
@@ -443,29 +431,5 @@ def test_unfollow_user_successfully(auth_login_client, populate_users, follow_ur
     assert response.status_code == status.HTTP_201_CREATED
 
     #Unfollow
-    unfollow_response = client.post(unfollow_url(), {"user_id": user2.user.id} ,secure=True, format='json')
+    unfollow_response = client.post(follow_url(), {"user_id": user2.user.id} ,secure=True, format='json')
     assert unfollow_response.status_code == status.HTTP_200_OK
-
-@pytest.mark.django_db
-def test_unfollow_user_not_following(auth_login_client, populate_users, unfollow_url):
-    user1, user2, _ = populate_users
-    client = auth_login_client(user1.user.username, '1234')
-
-    unfollow_response = client.post(unfollow_url(), {"user_id": user2.user.id}, secure=True, format='json')
-    assert unfollow_response.status_code == status.HTTP_400_BAD_REQUEST
-
-@pytest.mark.django_db
-def test_user_cannot_unfollow_themselves(auth_login_client, populate_users, unfollow_url):
-    user1, _, _ = populate_users
-    client = auth_login_client(user1.user.username, '1234')
-
-    response = client.post(unfollow_url(), {"user_id": user1.user.id},secure=True, format='json')
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-@pytest.mark.django_db
-def test_user_unfollow_not_following(auth_login_client, populate_users, unfollow_url):
-    user1, user2, _ = populate_users
-    client = auth_login_client(user1.user.username, '1234')
-
-    response = client.post(unfollow_url(), {"user_id": user2.user.id}, secure=True, format='json')
-    assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
This PR refactors the Follow/Unfollow API to handle both actions within a single endpoint, simplifying the logic and improving efficiency.

- Updated FollowSerializer to toggle follow/unfollow based on existing relationships.
- Modified FollowView to support both following and unfollowing in a single request.
- Removed redundant validation checks (e.g., ensuring a user follows before unfollowing).
- Updated test cases to reflect the new behavior.
- Removed obsolete tests that no longer apply to the updated logic.